### PR TITLE
Fix _create_instrument_mapping bug and support of record trades only

### DIFF
--- a/befh/exchange/exchange.py
+++ b/befh/exchange/exchange.py
@@ -21,6 +21,7 @@ class Exchange:
         self._config = config
         self._is_debug = is_debug
         self._is_cold = is_cold
+        self._is_orders = True
         self._instruments = {}
         self._depth = Exchange.DEFAULT_DEPTH
         self._last_request_time = datetime(1990, 1, 1)
@@ -58,6 +59,7 @@ class Exchange:
         self._load_handlers(handlers=handlers)
         self._load_instruments()
         self._load_depth()
+        self._load_is_orders()
 
     def _load_handlers(self, handlers):
         """Load handlers.
@@ -87,3 +89,12 @@ class Exchange:
             assert isinstance(self._depth, int), (
                 "Depth ({}) must be an integer".format(
                     self._depth))
+        
+    def _load_is_orders(self):
+        """Load is_orders.
+        """
+        if 'is_orders' in self._config:
+            self._is_orders = self._config['is_orders']
+            assert isinstance(self._is_orders, bool), (
+                "is_orders ({}) must be an boolean".format(
+                    self._is_orders))    

--- a/befh/exchange/websocket_exchange.py
+++ b/befh/exchange/websocket_exchange.py
@@ -70,6 +70,10 @@ class WebsocketExchange(RestApiExchange):
         name = name.capitalize()
         if name == 'Hitbtc':
             return 'HitBTC'
+        elif name == 'Okex':
+            return "OKEx"
+        elif name == "Huobipro":
+            return "Huobi"
 
         return name
 

--- a/befh/exchange/websocket_exchange.py
+++ b/befh/exchange/websocket_exchange.py
@@ -36,10 +36,15 @@ class WebsocketExchange(RestApiExchange):
             raise ImportError(
                 'Cannot load exchange %s from websocket' % self._name)
 
-        callbacks = {
-            L2_BOOK: BookCallback(self._update_order_book_callback),
-            TRADES: TradeCallback(self._update_trade_callback)
-        }
+        if self._is_orders:
+            callbacks = {
+                L2_BOOK: BookCallback(self._update_order_book_callback),
+                TRADES: TradeCallback(self._update_trade_callback)
+            }
+        else:
+            callbacks = {
+                TRADES: TradeCallback(self._update_trade_callback)
+            }            
 
         if self._name.lower() == 'poloniex':
             self._feed_handler.add_feed(

--- a/befh/exchange/websocket_exchange.py
+++ b/befh/exchange/websocket_exchange.py
@@ -128,8 +128,9 @@ class WebsocketExchange(RestApiExchange):
         """
         instmt_info = self._instruments[self._instrument_mapping[pair]]
         trade = {}
-
-        if self._name.lower() == 'bitmex':
+        
+        utcstr_timestamp_exchanges = ['bitmex', 'okex']
+        if self._name.lower() in utcstr_timestamp_exchanges:
             timestamp = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
             timestamp = timestamp.timestamp()
             trade['timestamp'] = timestamp

--- a/befh/handler/handler_operator.py
+++ b/befh/handler/handler_operator.py
@@ -13,6 +13,13 @@ class HandlerOperator:
         """
         raise NotImplementedError(
             'Execute is not implemented')
+    
+    @staticmethod
+    def parse_table_name(table_name):
+        """parse table name fix sqlalchemy can't insert table name with '.'.
+        """
+            
+        return table_name.replace('.', '')
 
 
 class HandlerCloseOperator(HandlerOperator):
@@ -33,7 +40,7 @@ class HandlerCreateTableOperator(HandlerOperator):
         """Constructor.
         """
         super().__init__(**kwargs)
-        self._table_name = table_name
+        self._table_name = self.parse_table_name(table_name)
         self._fields = fields
 
     def execute(self, handler):
@@ -52,7 +59,7 @@ class HandlerInsertOperator(HandlerOperator):
         """Constructor.
         """
         super().__init__(**kwargs)
-        self._table_name = table_name
+        self._table_name = self.parse_table_name(table_name)
         self._fields = fields
 
     def execute(self, handler):
@@ -72,8 +79,8 @@ class HandlerRenameTableOperator(HandlerOperator):
         """Constructor.
         """
         super().__init__(**kwargs)
-        self._from_name = from_name
-        self._to_name = to_name
+        self._from_name = self.parse_table_name(from_name)
+        self._to_name = self.parse_table_name(to_name)
         self._fields = fields
         self._keep_table = keep_table
 


### PR DESCRIPTION
「fixes #148 #149」
I need to record the indices of bitmex, but the cryptofeed record indices can only request TRADES. If L2_BOOK is requested at the same time, an error will be reported. Therefore, I add a configuration switch is_orders, which can switch the request for L2_BOOK in the configuration file.
In addition, the indices records of bitmex also induce the sqlalchemy bug.Since the indices of bitmex always starts with ".", such as.BXBT, sqlalchemy can only create tables with ".", but the corresponding table does not exist in the insert table.
These problems, I also fix in the fork version.